### PR TITLE
actions/setup-python@v4

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.7'
     - name: Install ruff package


### PR DESCRIPTION
Fixed #2 

I usually do not even set up Python for a Ruff-only job run because the job takes twice as long and because Ruff is written in Rust, not Python so we need pip to do the install but we do not need Python.